### PR TITLE
German translation "Powered by Matrix"

### DIFF
--- a/src/i18n/strings/de_DE.json
+++ b/src/i18n/strings/de_DE.json
@@ -1,5 +1,5 @@
 {
-    "powered by Matrix": "betrieben mit Matrix",
+    "powered by Matrix": "Betrieben mit Matrix",
     "Dismiss": "Ausblenden",
     "Unknown device": "Unbekanntes Gerät",
     "You need to be using HTTPS to place a screen-sharing call.": "Du musst HTTPS nutzen um einen Anruf mit Bildschirmfreigabe durchzuführen.",
@@ -31,6 +31,5 @@
     "Download Completed": "Download fertiggestellt",
     "Open": "Öffnen",
     "%(brand)s uses advanced browser features which aren't supported by your current browser.": "%(brand)s verwendet erweiterte Browserfunktionen, die von Ihrem aktuellen Browser nicht unterstützt werden.",
-    "Your browser can't run %(brand)s": "Dein Browser kann %(brand)s nicht ausführen",
-    "Powered by Matrix": "Betrieben von Matrix"
+    "Your browser can't run %(brand)s": "Dein Browser kann %(brand)s nicht ausführen"
 }


### PR DESCRIPTION
The german translation of "_Powered by Matrix_" was shown as "_Betrieben von Matrix_" which can be missinterpreted as if the organisation "Matrix" is providing/running this services instead to say it's using Matrix technology.

Also this translation was listed twice, so I removed the missleading one and changed the other one to begin with a capital Letter.